### PR TITLE
Oppdaterer avhengigheter

### DIFF
--- a/Difi.Oppslagstjeneste.Klient.Domene/Difi.Oppslagstjeneste.Klient.Domene.csproj
+++ b/Difi.Oppslagstjeneste.Klient.Domene/Difi.Oppslagstjeneste.Klient.Domene.csproj
@@ -39,12 +39,12 @@
     <AssemblyOriginatorKeyFile>C:\Keys\digipost.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ApiClientShared, Version=1.0.5941.27271, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\api-client-shared.1.0.5941.27271\lib\net45\ApiClientShared.dll</HintPath>
+    <Reference Include="ApiClientShared, Version=1.0.5968.19413, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\api-client-shared.1.0.5968.19413\lib\net45\ApiClientShared.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Difi.Felles.Utility, Version=0.6.6008.19059, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\difi-felles-utility-dotnet.0.6.6008.19059\lib\net45\Difi.Felles.Utility.dll</HintPath>
+    <Reference Include="Difi.Felles.Utility, Version=0.8.0.27738, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\difi-felles-utility-dotnet.0.8.0.27738\lib\net45\Difi.Felles.Utility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -70,6 +70,7 @@
     <Compile Include="Entiteter\Kontaktinformasjon.cs" />
     <Compile Include="Entiteter\Mobiltelefonnummer.cs" />
     <Compile Include="Entiteter\Person.cs" />
+    <Compile Include="Extensions\EnumExtensions.cs" />
     <Compile Include="Navnerom.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Entiteter\Sikkerdigitalpostadresse.cs" />

--- a/Difi.Oppslagstjeneste.Klient.Domene/Extensions/EnumExtensions.cs
+++ b/Difi.Oppslagstjeneste.Klient.Domene/Extensions/EnumExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Difi.Felles.Utility;
+
+namespace Difi.Oppslagstjeneste.Klient.Domene.Extensions
+{
+    internal static class EnumExtensions
+    {
+        public static string ToNorwegianString(this CertificateValidationType certificateValidationType)
+        {
+            switch (certificateValidationType)
+            {
+                case CertificateValidationType.Valid:
+                    return "Gyldig";
+                case CertificateValidationType.InvalidCertificate:
+                    return "UgyldigSertifikat";
+                case CertificateValidationType.InvalidChain:
+                    return "UgyldigKjede";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(certificateValidationType), certificateValidationType, null);
+            }
+        }
+
+    }
+}

--- a/Difi.Oppslagstjeneste.Klient.Domene/Properties/AssemblyInfo.cs
+++ b/Difi.Oppslagstjeneste.Klient.Domene/Properties/AssemblyInfo.cs
@@ -2,26 +2,9 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
 [assembly: AssemblyTitle("Difi.Oppslagstjeneste.Klient.Domene")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Difi.Oppslagstjeneste.Klient.Domene")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
 [assembly: ComVisible(false)]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-
-[assembly: Guid("91aab4dd-d6ca-4a0e-961b-c758c8b3171f")]
 [assembly: InternalsVisibleTo("Difi.Oppslagstjeneste.Klient,PublicKey=00240000048000009400000006020000002400005253413100040000010001008b3388f9c416425f0145bbcf26e66b9a87c4e08b4cd41563e4bc8846df38ba4d997c5408cc77da26d79b03c39874a6af9df0aff3e7bdb3c0e53a91f6d19c50e160f5bf67986a04f0f985eca0252f557ed9ae520dd51e3107d6168d073d4ec5ada28d34e492ad9fb7af29c82309c5c0124211e679caea38d5463d2af9042dafda")]
+[assembly: InternalsVisibleTo("Difi.Oppslagstjeneste.Klient,PublicKey=00240000048000009400000006020000002400005253413100040000010001008b3388f9c416425f0145bbcf26e66b9a87c4e08b4cd41563e4bc8846df38ba4d997c5408cc77da26d79b03c39874a6af9df0aff3e7bdb3c0e53a91f6d19c50e160f5bf67986a04f0f985eca0252f557ed9ae520dd51e3107d6168d073d4ec5ada28d34e492ad9fb7af29c82309c5c0124211e679caea38d5463d2af9042dafda")]
+[assembly: InternalsVisibleTo("Difi.Oppslagstjeneste.Klient.Tests,PublicKey=00240000048000009400000006020000002400005253413100040000010001008b3388f9c416425f0145bbcf26e66b9a87c4e08b4cd41563e4bc8846df38ba4d997c5408cc77da26d79b03c39874a6af9df0aff3e7bdb3c0e53a91f6d19c50e160f5bf67986a04f0f985eca0252f557ed9ae520dd51e3107d6168d073d4ec5ada28d34e492ad9fb7af29c82309c5c0124211e679caea38d5463d2af9042dafda")]

--- a/Difi.Oppslagstjeneste.Klient.Domene/packages.config
+++ b/Difi.Oppslagstjeneste.Klient.Domene/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.0.5941.27271" targetFramework="net45" />
-  <package id="difi-felles-utility-dotnet" version="0.6.6008.19059" targetFramework="net45" />
+  <package id="api-client-shared" version="1.0.5968.19413" targetFramework="net45" />
+  <package id="difi-felles-utility-dotnet" version="0.8.0.27738" targetFramework="net45" />
 </packages>

--- a/Difi.Oppslagstjeneste.Klient.Resources/Difi.Oppslagstjeneste.Klient.Resources.csproj
+++ b/Difi.Oppslagstjeneste.Klient.Resources/Difi.Oppslagstjeneste.Klient.Resources.csproj
@@ -37,8 +37,8 @@
     <AssemblyOriginatorKeyFile>C:\Keys\digipost.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ApiClientShared, Version=1.0.5941.27271, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\api-client-shared.1.0.5941.27271\lib\net45\ApiClientShared.dll</HintPath>
+    <Reference Include="ApiClientShared, Version=1.0.5968.19413, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\api-client-shared.1.0.5968.19413\lib\net45\ApiClientShared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Difi.Oppslagstjeneste.Klient.Resources/Properties/AssemblyInfo.cs
+++ b/Difi.Oppslagstjeneste.Klient.Resources/Properties/AssemblyInfo.cs
@@ -2,21 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
 [assembly: AssemblyTitle("Difi.Oppslagstjeneste.Klient.Resources")]
-[assembly: AssemblyProduct("Difi.Oppslagstjeneste.Klient.Resources")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
 [assembly: ComVisible(false)]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-
-[assembly: Guid("a52aafce-14df-4a33-af7c-9209fcba646c")]
 [assembly: InternalsVisibleTo("Difi.Oppslagstjeneste.Klient.Tests,PublicKey=00240000048000009400000006020000002400005253413100040000010001008b3388f9c416425f0145bbcf26e66b9a87c4e08b4cd41563e4bc8846df38ba4d997c5408cc77da26d79b03c39874a6af9df0aff3e7bdb3c0e53a91f6d19c50e160f5bf67986a04f0f985eca0252f557ed9ae520dd51e3107d6168d073d4ec5ada28d34e492ad9fb7af29c82309c5c0124211e679caea38d5463d2af9042dafda")]

--- a/Difi.Oppslagstjeneste.Klient.Resources/packages.config
+++ b/Difi.Oppslagstjeneste.Klient.Resources/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.0.5941.27271" targetFramework="net45" />
+  <package id="api-client-shared" version="1.0.5968.19413" targetFramework="net45" />
 </packages>

--- a/Difi.Oppslagstjeneste.Klient.Scripts/Properties/AssemblyInfo.cs
+++ b/Difi.Oppslagstjeneste.Klient.Scripts/Properties/AssemblyInfo.cs
@@ -1,25 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
 [assembly: AssemblyTitle("Difi.Oppslagstjeneste.Klient.Scripts")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Difi.Oppslagstjeneste.Klient.Scripts")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-
-[assembly: Guid("2dd9a89b-e1b4-4dc4-ba46-1d58ab0b0200")]

--- a/Difi.Oppslagstjeneste.Klient.Tester/Difi.Oppslagstjeneste.Klient.Tests.csproj
+++ b/Difi.Oppslagstjeneste.Klient.Tester/Difi.Oppslagstjeneste.Klient.Tests.csproj
@@ -43,8 +43,8 @@
     <AssemblyOriginatorKeyFile>C:\Keys\digipost.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ApiClientShared, Version=1.0.5941.27271, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\api-client-shared.1.0.5941.27271\lib\net45\ApiClientShared.dll</HintPath>
+    <Reference Include="ApiClientShared, Version=1.0.5968.19413, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\api-client-shared.1.0.5968.19413\lib\net45\ApiClientShared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
@@ -55,8 +55,8 @@
       <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Difi.Felles.Utility, Version=0.6.6008.19059, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\difi-felles-utility-dotnet.0.6.6008.19059\lib\net45\Difi.Felles.Utility.dll</HintPath>
+    <Reference Include="Difi.Felles.Utility, Version=0.8.0.27738, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\difi-felles-utility-dotnet.0.8.0.27738\lib\net45\Difi.Felles.Utility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="KellermanSoftware.Compare-NET-Objects, Version=3.4.0.0, Culture=neutral, PublicKeyToken=d970ace04cc85217, processorArchitecture=MSIL">
@@ -89,6 +89,7 @@
     <Compile Include="Envelope\PersonerEnvelopeTests.cs" />
     <Compile Include="Envelope\PrintSertifikatEnvelopeTests.cs" />
     <Compile Include="DtoConverterTests.cs" />
+    <Compile Include="Extensions\EnumExtensionsTests.cs" />
     <Compile Include="Fakes\FakeHttpClientHandler.cs" />
     <Compile Include="Fakes\FakeHttpClientHandlerResponse.cs" />
     <Compile Include="Smoke\SmokeTests.cs" />

--- a/Difi.Oppslagstjeneste.Klient.Tester/Extensions/EnumExtensionsTests.cs
+++ b/Difi.Oppslagstjeneste.Klient.Tester/Extensions/EnumExtensionsTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq;
+using Difi.Felles.Utility;
+using Difi.Oppslagstjeneste.Klient.Domene.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Difi.Oppslagstjeneste.Klient.Tests.Extensions
+{
+    [TestClass]
+    public class EnumExtensionsTests
+    {
+        [TestClass]
+        public class ToNorwegianStringMethod
+        {
+            [TestMethod]
+            public void Converts_all_enum_values()
+            {
+                var certificateValidationTypes = Enum.GetValues(typeof(CertificateValidationType)).Cast<CertificateValidationType>();
+
+                foreach (var certificateValidationType in certificateValidationTypes)
+                {
+                    certificateValidationType.ToNorwegianString();
+                }
+            }
+        }
+
+    }
+}

--- a/Difi.Oppslagstjeneste.Klient.Tester/MiljøTests.cs
+++ b/Difi.Oppslagstjeneste.Klient.Tester/MiljøTests.cs
@@ -7,43 +7,43 @@ namespace Difi.Oppslagstjeneste.Klient.Tests
     public class MiljøTests
     {
         [TestMethod]
-        public void ReturnsInitializedFunctionalTestEnvironmentVer1()
+        public void Returns_initialized_functional_test_environment_ver1()
         {
             //Arrange
-            var url = "https://kontaktinfo-ws-ver1.difi.no/kontaktinfo-external/ws-v5";
             var environment = Miljø.FunksjoneltTestmiljøVerifikasjon1;
-            var certificates = CertificateChainUtility.FunksjoneltTestmiljøSertifikater();
+            const string url = "https://kontaktinfo-ws-ver1.difi.no/kontaktinfo-external/ws-v5";
+            var certificates = CertificateChainUtility.ProduksjonsSertifikater();
 
             //Act
 
             //Assert
             Assert.IsNotNull(environment.CertificateChainValidator);
             Assert.AreEqual(url, environment.Url.AbsoluteUri);
-            CollectionAssert.AreEqual(certificates, environment.CertificateChainValidator.SertifikatLager);
+            CollectionAssert.AreEqual(certificates, environment.CertificateChainValidator.CertificateStore);
         }
 
         [TestMethod]
-        public void ReturnsInitializedFunctionalTestEnvironmentVer2()
+        public void Returns_initialized_functional_test_environment_ver2()
         {
             //Arrange
-            var url = "https://kontaktinfo-ws-ver2.difi.no/kontaktinfo-external/ws-v5";
             var environment = Miljø.FunksjoneltTestmiljøVerifikasjon2;
-            var certificates = CertificateChainUtility.FunksjoneltTestmiljøSertifikater();
+            const string url = "https://kontaktinfo-ws-ver2.difi.no/kontaktinfo-external/ws-v5";
+            var certificates = CertificateChainUtility.ProduksjonsSertifikater();
 
             //Act
 
             //Assert
             Assert.IsNotNull(environment.CertificateChainValidator);
             Assert.AreEqual(url, environment.Url.AbsoluteUri);
-            CollectionAssert.AreEqual(certificates, environment.CertificateChainValidator.SertifikatLager);
+            CollectionAssert.AreEqual(certificates, environment.CertificateChainValidator.CertificateStore);
         }
 
         [TestMethod]
-        public void ReturnsInitializedProductionEnvironment()
+        public void Returns_initialized_production_environment()
         {
             //Arrange
-            var url = "https://kontaktinfo-ws.difi.no/kontaktinfo-external/ws-v5";
             var environment = Miljø.Produksjonsmiljø;
+            const string url = "https://kontaktinfo-ws.difi.no/kontaktinfo-external/ws-v5";
             var certificates = CertificateChainUtility.ProduksjonsSertifikater();
 
             //Act
@@ -51,7 +51,7 @@ namespace Difi.Oppslagstjeneste.Klient.Tests
             //Assert
             Assert.IsNotNull(environment.CertificateChainValidator);
             Assert.AreEqual(url, environment.Url.ToString());
-            CollectionAssert.AreEqual(certificates, environment.CertificateChainValidator.SertifikatLager);
+            CollectionAssert.AreEqual(certificates, environment.CertificateChainValidator.CertificateStore);
         }
     }
 }

--- a/Difi.Oppslagstjeneste.Klient.Tester/Properties/AssemblyInfo.cs
+++ b/Difi.Oppslagstjeneste.Klient.Tester/Properties/AssemblyInfo.cs
@@ -1,25 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
 [assembly: AssemblyTitle("Difi.Oppslagstjeneste.Klient.Tests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Difi.Oppslagstjeneste.Klient.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-
-[assembly: Guid("ec36facd-03e5-4d40-9e75-028fda89ec34")]

--- a/Difi.Oppslagstjeneste.Klient.Tester/packages.config
+++ b/Difi.Oppslagstjeneste.Klient.Tester/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.0.5941.27271" targetFramework="net45" />
+  <package id="api-client-shared" version="1.0.5968.19413" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="CompareNETObjects" version="3.04.0.0" targetFramework="net45" />
   <package id="CompareObjects" version="1.0.2" targetFramework="net45" />
-  <package id="difi-felles-utility-dotnet" version="0.6.6008.19059" targetFramework="net45" />
+  <package id="difi-felles-utility-dotnet" version="0.8.0.27738" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
 </packages>

--- a/Difi.Oppslagstjeneste.Klient.Testklient/Properties/AssemblyInfo.cs
+++ b/Difi.Oppslagstjeneste.Klient.Testklient/Properties/AssemblyInfo.cs
@@ -1,25 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
 [assembly: AssemblyTitle("Difi.Oppslagstjeneste.Klient.Testklient")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Difi.Oppslagstjeneste.Klient.Testklient")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-
-[assembly: Guid("e4b81304-0c3c-479d-bdbd-870435cc9436")]

--- a/Difi.Oppslagstjeneste.Klient/Difi.Oppslagstjeneste.Klient.csproj
+++ b/Difi.Oppslagstjeneste.Klient/Difi.Oppslagstjeneste.Klient.csproj
@@ -43,8 +43,8 @@
     <AssemblyOriginatorKeyFile>C:\Keys\digipost.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ApiClientShared, Version=1.0.5941.27271, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\api-client-shared.1.0.5941.27271\lib\net45\ApiClientShared.dll</HintPath>
+    <Reference Include="ApiClientShared">
+      <HintPath>..\packages\api-client-shared.1.0.5968.19413\lib\net45\ApiClientShared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
@@ -55,8 +55,8 @@
       <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Difi.Felles.Utility, Version=0.6.6008.19059, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\difi-felles-utility-dotnet.0.6.6008.19059\lib\net45\Difi.Felles.Utility.dll</HintPath>
+    <Reference Include="Difi.Felles.Utility">
+      <HintPath>..\packages\difi-felles-utility-dotnet.0.8.0.27738\lib\net45\Difi.Felles.Utility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Difi.Oppslagstjeneste.Klient/Miljø.cs
+++ b/Difi.Oppslagstjeneste.Klient/Miljø.cs
@@ -26,7 +26,7 @@ namespace Difi.Oppslagstjeneste.Klient
         /// </summary>
         public static Miljø FunksjoneltTestmiljøVerifikasjon1 => new Miljø(
             new Uri("https://kontaktinfo-ws-ver1.difi.no/kontaktinfo-external/ws-v5"),
-            new CertificateChainValidator(CertificateChainUtility.FunksjoneltTestmiljøSertifikater())
+            new CertificateChainValidator(CertificateChainUtility.ProduksjonsSertifikater())
             );
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Difi.Oppslagstjeneste.Klient
         /// </summary>
         public static Miljø FunksjoneltTestmiljøVerifikasjon2 => new Miljø(
             new Uri("https://kontaktinfo-ws-ver2.difi.no/kontaktinfo-external/ws-v5"),
-            new CertificateChainValidator(CertificateChainUtility.FunksjoneltTestmiljøSertifikater())
+            new CertificateChainValidator(CertificateChainUtility.ProduksjonsSertifikater())
             );
 
         public static Miljø Produksjonsmiljø => new Miljø(

--- a/Difi.Oppslagstjeneste.Klient/Properties/AssemblyInfo.cs
+++ b/Difi.Oppslagstjeneste.Klient/Properties/AssemblyInfo.cs
@@ -7,22 +7,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 
 [assembly: AssemblyTitle("Difi.Oppslagstjeneste.Klient")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Difi.Oppslagstjeneste.Klient")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
 [assembly: ComVisible(false)]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-
-[assembly: Guid("57309590-e044-4029-9268-7bb6c98e0989")]
 [assembly: InternalsVisibleTo("Difi.Oppslagstjeneste.Klient.Tests,PublicKey=00240000048000009400000006020000002400005253413100040000010001008b3388f9c416425f0145bbcf26e66b9a87c4e08b4cd41563e4bc8846df38ba4d997c5408cc77da26d79b03c39874a6af9df0aff3e7bdb3c0e53a91f6d19c50e160f5bf67986a04f0f985eca0252f557ed9ae520dd51e3107d6168d073d4ec5ada28d34e492ad9fb7af29c82309c5c0124211e679caea38d5463d2af9042dafda")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/Difi.Oppslagstjeneste.Klient/packages.config
+++ b/Difi.Oppslagstjeneste.Klient/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.0.5941.27271" targetFramework="net45" />
+  <package id="api-client-shared" version="1.0.5968.19413" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
-  <package id="difi-felles-utility-dotnet" version="0.6.6008.19059" targetFramework="net45" />
+  <package id="difi-felles-utility-dotnet" version="0.8.0.27738" targetFramework="net45" />
 </packages>

--- a/SolutionItems/SharedAssemblyInfo.cs
+++ b/SolutionItems/SharedAssemblyInfo.cs
@@ -1,11 +1,12 @@
 using System.Reflection;
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-
-[assembly: AssemblyVersion("5.3.*")]
-[assembly: AssemblyFileVersion("5.3.*")]
+[assembly: AssemblyCompany("Direktoratet for forvaltning og IKT (Difi)")]
+[assembly: AssemblyTrademark("Direktoratet for forvaltning og IKT (Difi)")]
+[assembly: AssemblyProduct("Difi Opppslagstjeneste Klient")]
+[assembly: AssemblyDescription("Klientbibliotek for integrasjon mot Oppslagstjenesten for kontakt og reservasjonregisteret")]
+[assembly: AssemblyVersion("5.4.0.*")]
+#pragma warning disable CS7035 // The specified version string does not conform to the recommended format - major.minor.build.revision
+[assembly: AssemblyFileVersion("5.4.0.*")]
+#pragma warning restore CS7035 // The specified version string does not conform to the recommended format - major.minor.build.revision
+[assembly: AssemblyCopyright("© 2015-2016 Direktoratet for forvaltning og IKT (Difi)")]
+[assembly: AssemblyCulture("")]

--- a/difi-oppslagstjeneste-klient.nuspec
+++ b/difi-oppslagstjeneste-klient.nuspec
@@ -12,8 +12,8 @@
         <tags>Difi Oppslagstjeneste Sikker Digital Post SikkerDigitalPost</tags>
         <dependencies>
             <group targetFramework=".NETFramework4.5">
-                <dependency id="difi-felles-utility-dotnet" version="[0.6.6008.19059,0.7)"/>
-                <dependency id="api-client-shared" version="[1.0.5941.27271,1.1)" />
+                <dependency id="difi-felles-utility-dotnet" version="[0.8.0.27738,1.0)"/>
+                <dependency id="api-client-shared" version="[1.0.5968.19413,2.0)" />
                 <dependency id="Common.Logging" version="[3.3.1,3.4)" />
                 <dependency id="Common.Logging.Core" version="[3.3.1,3.4)" />
             </group>


### PR DESCRIPTION
- Fikser #71 - Nå valideres respons med produksjonssertifikater uansett miljø.
- Oppdaterer AssemblyInfo til å ikke være duplisert og spredd over alle prosjekter
- Bedre feilmelding om validering av responssertifikat feiler.