### PR TITLE
Oppdaterer avhengighet til api-client-shared

### DIFF
--- a/Difi.Oppslagstjeneste.Klient.Domene/Difi.Oppslagstjeneste.Klient.Domene.csproj
+++ b/Difi.Oppslagstjeneste.Klient.Domene/Difi.Oppslagstjeneste.Klient.Domene.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Difi.Oppslagstjeneste.Klient.Domene</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,8 +40,8 @@
     <AssemblyOriginatorKeyFile>C:\Keys\digipost.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ApiClientShared, Version=1.0.5968.19413, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\api-client-shared.1.0.5968.19413\lib\net45\ApiClientShared.dll</HintPath>
+    <Reference Include="ApiClientShared, Version=1.1.0.24133, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\api-client-shared.1.1.0.24133\lib\net45\ApiClientShared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Difi.Felles.Utility, Version=0.8.0.27738, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
@@ -79,9 +80,7 @@
     <None Include="..\difi-oppslagstjeneste.pfx">
       <Link>Properties\difi-oppslagstjeneste.pfx</Link>
     </None>
-    <None Include="app.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />

--- a/Difi.Oppslagstjeneste.Klient.Domene/app.config
+++ b/Difi.Oppslagstjeneste.Klient.Domene/app.config
@@ -1,3 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
+  <configSections>
+    <sectionGroup name="common">
+      <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />
+    </sectionGroup>
+  </configSections>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="ApiClientShared" publicKeyToken="683b8efceae684a6" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.5968.19413" newVersion="1.1.0.24133" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  
+  <common>
+    <logging>
+      <factoryAdapter type="Common.Logging.Simple.ConsoleOutLoggerFactoryAdapter, Common.Logging">
+        <arg key="level" value="ALL" />
+        <arg key="showLogName" value="false" />
+        <arg key="showDataTime" value="false" />
+        <arg key="dateTimeFormat" value="yyyy/MM/dd HH:mm:ss:fff" />
+      </factoryAdapter>
+    </logging>
+  </common>
 </configuration>

--- a/Difi.Oppslagstjeneste.Klient.Domene/packages.config
+++ b/Difi.Oppslagstjeneste.Klient.Domene/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.0.5968.19413" targetFramework="net45" />
+  <package id="api-client-shared" version="1.1.0.24133" targetFramework="net45" />
   <package id="difi-felles-utility-dotnet" version="0.8.0.27738" targetFramework="net45" />
 </packages>

--- a/Difi.Oppslagstjeneste.Klient.Resources/Difi.Oppslagstjeneste.Klient.Resources.csproj
+++ b/Difi.Oppslagstjeneste.Klient.Resources/Difi.Oppslagstjeneste.Klient.Resources.csproj
@@ -37,8 +37,8 @@
     <AssemblyOriginatorKeyFile>C:\Keys\digipost.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ApiClientShared, Version=1.0.5968.19413, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\api-client-shared.1.0.5968.19413\lib\net45\ApiClientShared.dll</HintPath>
+    <Reference Include="ApiClientShared, Version=1.1.0.24133, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\api-client-shared.1.1.0.24133\lib\net45\ApiClientShared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Difi.Oppslagstjeneste.Klient.Resources/packages.config
+++ b/Difi.Oppslagstjeneste.Klient.Resources/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.0.5968.19413" targetFramework="net45" />
+  <package id="api-client-shared" version="1.1.0.24133" targetFramework="net45" />
 </packages>

--- a/Difi.Oppslagstjeneste.Klient.Tester/Difi.Oppslagstjeneste.Klient.Tests.csproj
+++ b/Difi.Oppslagstjeneste.Klient.Tester/Difi.Oppslagstjeneste.Klient.Tests.csproj
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,8 +44,12 @@
     <AssemblyOriginatorKeyFile>C:\Keys\digipost.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ApiClientShared, Version=1.0.5968.19413, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\api-client-shared.1.0.5968.19413\lib\net45\ApiClientShared.dll</HintPath>
+    <Reference Include="ApiClientShared, Version=1.1.0.24133, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\api-client-shared.1.1.0.24133\lib\net45\ApiClientShared.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
@@ -59,13 +64,13 @@
       <HintPath>..\packages\difi-felles-utility-dotnet.0.8.0.27738\lib\net45\Difi.Felles.Utility.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="KellermanSoftware.Compare-NET-Objects, Version=3.4.0.0, Culture=neutral, PublicKeyToken=d970ace04cc85217, processorArchitecture=MSIL">
-      <HintPath>..\packages\CompareNETObjects.3.04.0.0\lib\net45\KellermanSoftware.Compare-NET-Objects.dll</HintPath>
+    <Reference Include="KellermanSoftware.Compare-NET-Objects, Version=3.5.0.0, Culture=neutral, PublicKeyToken=d970ace04cc85217, processorArchitecture=MSIL">
+      <HintPath>..\packages\CompareNETObjects.3.05.0.0\lib\net45\KellermanSoftware.Compare-NET-Objects.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.5.23.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.5.23\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Difi.Oppslagstjeneste.Klient.Tester/packages.config
+++ b/Difi.Oppslagstjeneste.Klient.Tester/packages.config
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.0.5968.19413" targetFramework="net45" />
+  <package id="api-client-shared" version="1.1.0.24133" targetFramework="net45" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
-  <package id="CompareNETObjects" version="3.04.0.0" targetFramework="net45" />
+  <package id="CompareNETObjects" version="3.05.0.0" targetFramework="net45" />
   <package id="CompareObjects" version="1.0.2" targetFramework="net45" />
   <package id="difi-felles-utility-dotnet" version="0.8.0.27738" targetFramework="net45" />
-  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="Moq" version="4.5.23" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/Difi.Oppslagstjeneste.Klient/Difi.Oppslagstjeneste.Klient.csproj
+++ b/Difi.Oppslagstjeneste.Klient/Difi.Oppslagstjeneste.Klient.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Difi.Oppslagstjeneste.Klient</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TEAMCITY_BUILD_PROPERTIES_FILE)' != ''">
     <TeamCityBuild>true</TeamCityBuild>
@@ -43,8 +44,8 @@
     <AssemblyOriginatorKeyFile>C:\Keys\digipost.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ApiClientShared">
-      <HintPath>..\packages\api-client-shared.1.0.5968.19413\lib\net45\ApiClientShared.dll</HintPath>
+    <Reference Include="ApiClientShared, Version=1.1.0.24133, Culture=neutral, PublicKeyToken=683b8efceae684a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\api-client-shared.1.1.0.24133\lib\net45\ApiClientShared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
@@ -98,8 +99,8 @@
     <Compile Include="XmlValidation\OppslagstjenesteXmlValidator.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config">
-      <SubType>Designer</SubType>
+    <None Include="..\SolutionItems\App.config">
+      <Link>App.config</Link>
     </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/Difi.Oppslagstjeneste.Klient/app.config
+++ b/Difi.Oppslagstjeneste.Klient/app.config
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-</configuration>

--- a/Difi.Oppslagstjeneste.Klient/packages.config
+++ b/Difi.Oppslagstjeneste.Klient/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="api-client-shared" version="1.0.5968.19413" targetFramework="net45" />
+  <package id="api-client-shared" version="1.1.0.24133" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="difi-felles-utility-dotnet" version="0.8.0.27738" targetFramework="net45" />

--- a/SolutionItems/App.config
+++ b/SolutionItems/App.config
@@ -9,6 +9,16 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
+
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="ApiClientShared" publicKeyToken="683b8efceae684a6" culture="neutral" />
+        <bindingRedirect oldVersion="1.0.5968.19413" newVersion="1.1.0.24133" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  
   <common>
     <logging>
       <factoryAdapter type="Common.Logging.Simple.ConsoleOutLoggerFactoryAdapter, Common.Logging">

--- a/SolutionItems/SharedAssemblyInfo.cs
+++ b/SolutionItems/SharedAssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 [assembly: AssemblyTrademark("Direktoratet for forvaltning og IKT (Difi)")]
 [assembly: AssemblyProduct("Difi Opppslagstjeneste Klient")]
 [assembly: AssemblyDescription("Klientbibliotek for integrasjon mot Oppslagstjenesten for kontakt og reservasjonregisteret")]
-[assembly: AssemblyVersion("5.4.0.*")]
+[assembly: AssemblyVersion("5.5.0.*")]
 #pragma warning disable CS7035 // The specified version string does not conform to the recommended format - major.minor.build.revision
-[assembly: AssemblyFileVersion("5.4.0.*")]
+[assembly: AssemblyFileVersion("5.5.0.*")]
 #pragma warning restore CS7035 // The specified version string does not conform to the recommended format - major.minor.build.revision
 [assembly: AssemblyCopyright("© 2015-2016 Direktoratet for forvaltning og IKT (Difi)")]
 [assembly: AssemblyCulture("")]

--- a/difi-oppslagstjeneste-klient.nuspec
+++ b/difi-oppslagstjeneste-klient.nuspec
@@ -13,7 +13,7 @@
         <dependencies>
             <group targetFramework=".NETFramework4.5">
                 <dependency id="difi-felles-utility-dotnet" version="[0.8.0.27738,1.0)"/>
-                <dependency id="api-client-shared" version="[1.0.5968.19413,2.0)" />
+                <dependency id="api-client-shared" version="[1.1.0.24133,2.0)" />
                 <dependency id="Common.Logging" version="[3.3.1,3.4)" />
                 <dependency id="Common.Logging.Core" version="[3.3.1,3.4)" />
             </group>


### PR DESCRIPTION
Hovedpoenget med denne PRen reflekteres absolutt ikke av branchnavnet. Her oppdaterer vi `api-client-shared` slik at vi kan laste sertifikater fra _LocalMachine_. For å gjøre dette så har vi også lagt til en redirect som gjør at `difi-felles-utility` bruker den samme versjonen av `api-client-shared`.