### PR TITLE
Bedre loggmeldinger og exceptionbeskrivelse

### DIFF
--- a/Difi.Oppslagstjeneste.Klient.Domene/Exceptions/UventetFeilException.cs
+++ b/Difi.Oppslagstjeneste.Klient.Domene/Exceptions/UventetFeilException.cs
@@ -16,6 +16,8 @@ namespace Difi.Oppslagstjeneste.Klient.Domene.Exceptions
             ParseToClassMembers(xml);
         }
 
+        public override string Message => Beskrivelse;
+
         public XmlDocument Xml { get; set; }
 
         public string Skyldig { get; set; }

--- a/Difi.Oppslagstjeneste.Klient/OppslagstjenesteKlient.cs
+++ b/Difi.Oppslagstjeneste.Klient/OppslagstjenesteKlient.cs
@@ -85,7 +85,8 @@ namespace Difi.Oppslagstjeneste.Klient
         {
             var requestEnvelope = new EndringerEnvelope(OppslagstjenesteKonfigurasjon.Avsendersertifikat, OppslagstjenesteKonfigurasjon.SendPåVegneAv, fraEndringsNummer, informasjonsbehov);
 
-            Log.Debug($"HentEndringerAsynkront(fraEndringsNummer:{fraEndringsNummer} , informasjonsbehov:{informasjonsbehov})");
+            Log.Debug($"HentEndringerAsynkront(fraEndringsNummer:{fraEndringsNummer} , informasjonsbehov:{string.Join(", ", informasjonsbehov)})");
+
             if (RequestAndResponseLog.IsDebugEnabled && OppslagstjenesteKonfigurasjon.LoggForespørselOgRespons)
             {
                 RequestAndResponseLog.Debug(requestEnvelope.XmlDocument.OuterXml);
@@ -137,7 +138,7 @@ namespace Difi.Oppslagstjeneste.Klient
         public async Task<IEnumerable<Person>> HentPersonerAsynkront(string[] personidentifikator, params Informasjonsbehov[] informasjonsbehov)
         {
             var requestEnvelope = new PersonsEnvelope(OppslagstjenesteKonfigurasjon.Avsendersertifikat, OppslagstjenesteKonfigurasjon.SendPåVegneAv, personidentifikator, informasjonsbehov);
-            Log.Debug($"HentPersonerAsynkront(personidentifikator:{personidentifikator} , informasjonsbehov:{informasjonsbehov})");
+            Log.Debug($"HentPersonerAsynkront(personidentifikator:{string.Join(", ", personidentifikator)} , informasjonsbehov:{string.Join(", ", informasjonsbehov)}");
             if (RequestAndResponseLog.IsDebugEnabled && OppslagstjenesteKonfigurasjon.LoggForespørselOgRespons)
             {
                 RequestAndResponseLog.Debug(requestEnvelope.XmlDocument.OuterXml);

--- a/Difi.Oppslagstjeneste.Klient/OppslagstjenesteKlient.cs
+++ b/Difi.Oppslagstjeneste.Klient/OppslagstjenesteKlient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Common.Logging;
@@ -50,12 +51,11 @@ namespace Difi.Oppslagstjeneste.Klient
         ///     Forespørsel sendt fra Virksomhet for å hente endringer fra Oppslagstjenesten.
         /// </summary>
         /// <param name="fraEndringsNummer">
-        ///     Brukes i endringsforespørsler for å hente alle endringer fra og med et bestemt
-        ///     endringsNummer.
+        ///     Brukes i endringsforespørsler for å hente alle endringer fra og med et bestemt endringsnummer.
         /// </param>
         /// <param name="informasjonsbehov">
-        ///     Beskriver det opplysningskrav som en Virksomhet har definert. Du kan angi fler behov
-        ///     f.eks Informasjonsbehov.Kontaktinfo | Informasjonsbehov.SikkerDigitalPost.
+        ///     Beskriver det opplysningskrav som en Virksomhet har definert. Du kan angi flere behov, som for eksempel
+        ///     <see cref="Informasjonsbehov.Kontaktinfo" /> eller <see cref="Informasjonsbehov.VarslingsStatus" />.
         /// </param>
         public EndringerSvar HentEndringer(long fraEndringsNummer, params Informasjonsbehov[] informasjonsbehov)
         {
@@ -74,12 +74,11 @@ namespace Difi.Oppslagstjeneste.Klient
         ///     Forespørsel sendt fra Virksomhet for å hente endringer fra Oppslagstjenesten.
         /// </summary>
         /// <param name="fraEndringsNummer">
-        ///     Brukes i endringsforespørsler for å hente alle endringer fra og med et bestemt
-        ///     endringsNummer.
+        ///     Brukes i endringsforespørsler for å hente alle endringer fra og med et bestemt endringsnummer.
         /// </param>
         /// <param name="informasjonsbehov">
-        ///     Beskriver det opplysningskrav som en Virksomhet har definert. Du kan angi fler behov
-        ///     f.eks Informasjonsbehov.Kontaktinfo | Informasjonsbehov.SikkerDigitalPost.
+        ///     Beskriver det opplysningskrav som en Virksomhet har definert. Du kan angi flere behov, som for eksempel
+        ///     <see cref="Informasjonsbehov.Kontaktinfo" /> eller <see cref="Informasjonsbehov.VarslingsStatus" />.
         /// </param>
         public async Task<EndringerSvar> HentEndringerAsynkront(long fraEndringsNummer, params Informasjonsbehov[] informasjonsbehov)
         {
@@ -104,12 +103,11 @@ namespace Difi.Oppslagstjeneste.Klient
         ///     Forespørsel sendt fra Virksomhet for å hente Personer fra Oppslagstjenesten.
         /// </summary>
         /// <param name="personidentifikator">
-        ///     Identifikasjon av en person. Personidentifikator er er enten et fødselsnummer et
-        ///     gyldig D-nummer.
+        ///     Identifikasjon av en person. Personidentifikator er et fødselsnummer eller et gyldig D-nummer.
         /// </param>
         /// <param name="informasjonsbehov">
-        ///     Beskriver det opplysningskrav som en Virksomhet har definert. Du kan angi fler behov
-        ///     f.eks Informasjonsbehov.Kontaktinfo | Informasjonsbehov.SikkerDigitalPost.
+        ///     Beskriver det opplysningskrav som en Virksomhet har definert. Du kan angi flere behov, som for eksempel
+        ///     <see cref="Informasjonsbehov.Kontaktinfo" /> eller <see cref="Informasjonsbehov.VarslingsStatus" />.
         /// </param>
         public IEnumerable<Person> HentPersoner(string[] personidentifikator, params Informasjonsbehov[] informasjonsbehov)
         {
@@ -127,18 +125,20 @@ namespace Difi.Oppslagstjeneste.Klient
         /// <summary>
         ///     Forespørsel sendt fra Virksomhet for å hente Personer fra Oppslagstjenesten.
         /// </summary>
-        /// <param name="personidentifikator">
-        ///     Identifikasjon av en person. Personidentifikator er er enten et fødselsnummer et
-        ///     gyldig D-nummer.
+        /// <param name="personidentifikatorer">
+        ///     Identifikasjon av en person. Personidentifikator er et fødselsnummer eller et gyldig D-nummer.
         /// </param>
         /// <param name="informasjonsbehov">
-        ///     Beskriver det opplysningskrav som en Virksomhet har definert. Du kan angi fler behov
-        ///     f.eks Informasjonsbehov.Kontaktinfo | Informasjonsbehov.SikkerDigitalPost.
+        ///     Beskriver det opplysningskrav som en Virksomhet har definert. Du kan angi flere behov, som for eksempel
+        ///     <see cref="Informasjonsbehov.Kontaktinfo" /> eller <see cref="Informasjonsbehov.VarslingsStatus" />.
         /// </param>
-        public async Task<IEnumerable<Person>> HentPersonerAsynkront(string[] personidentifikator, params Informasjonsbehov[] informasjonsbehov)
+        public async Task<IEnumerable<Person>> HentPersonerAsynkront(string[] personidentifikatorer, params Informasjonsbehov[] informasjonsbehov)
         {
-            var requestEnvelope = new PersonsEnvelope(OppslagstjenesteKonfigurasjon.Avsendersertifikat, OppslagstjenesteKonfigurasjon.SendPåVegneAv, personidentifikator, informasjonsbehov);
-            Log.Debug($"HentPersonerAsynkront(personidentifikator:{string.Join(", ", personidentifikator)} , informasjonsbehov:{string.Join(", ", informasjonsbehov)}");
+            var requestEnvelope = new PersonsEnvelope(OppslagstjenesteKonfigurasjon.Avsendersertifikat, OppslagstjenesteKonfigurasjon.SendPåVegneAv, personidentifikatorer, informasjonsbehov);
+
+            var maskertePersonIdentifikatorer = string.Join(", ", personidentifikatorer.Select(p => p.Substring(0, 6) + "*****"));
+            Log.Debug($"HentPersonerAsynkront(personidentifikator:{maskertePersonIdentifikatorer} , informasjonsbehov:{string.Join(", ", informasjonsbehov)}");
+
             if (RequestAndResponseLog.IsDebugEnabled && OppslagstjenesteKonfigurasjon.LoggForespørselOgRespons)
             {
                 RequestAndResponseLog.Debug(requestEnvelope.XmlDocument.OuterXml);

--- a/SolutionItems/App.config
+++ b/SolutionItems/App.config
@@ -29,7 +29,7 @@
   
   <common>
     <logging>
-      <factoryAdapter type="Common.Logging.Simple.ConsoleOutLoggerFactoryAdapter, Common.Logging">
+      <factoryAdapter type="Common.Logging.Simple.TraceLoggerFactoryAdapter, Common.Logging">
         <arg key="level" value="ALL" />
         <arg key="showLogName" value="false" />
         <arg key="showDataTime" value="false" />


### PR DESCRIPTION
- Fikser #72 hvor beskrivelsen ikke hentes automatisk til loggrammeverk for `UventetFeilException`. Nå overrider vi Message og setter den til å være `Beskrivelse`.
-  Array hadde ikke korrekt `ToString` i `OppslagstjenesteKlient`, som førte til at kun typen ble eksponert. Nå kommer innholdet i arrayet ut.