### PR TITLE
Revert log4net instead of Common.logging. 

### DIFF
--- a/Difi.Oppslagstjeneste.Klient.Testklient/Difi.Oppslagstjeneste.Klient.Testklient.csproj
+++ b/Difi.Oppslagstjeneste.Klient.Testklient/Difi.Oppslagstjeneste.Klient.Testklient.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="log4net" Version="2.0.12"/>
+        <PackageReference Include="Common.Logging" Version="3.4.1"/>
     </ItemGroup>
 
     <PropertyGroup>

--- a/Difi.Oppslagstjeneste.Klient.Testklient/Program.cs
+++ b/Difi.Oppslagstjeneste.Klient.Testklient/Program.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Common.Logging;
 using Difi.Oppslagstjeneste.Klient.Domene.Entiteter.Enums;
-using log4net;
 
 namespace Difi.Oppslagstjeneste.Klient.Testklient
 {

--- a/Difi.Oppslagstjeneste.Klient/Difi.Oppslagstjeneste.Klient.csproj
+++ b/Difi.Oppslagstjeneste.Klient/Difi.Oppslagstjeneste.Klient.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Difi.Felles.Utility.Resources" Version="5.0.1"/>
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1"/>
         <PackageReference Include="Difi.Felles.Utility" Version="5.0.1"/>
-        <PackageReference Include="log4net" Version="2.0.12"/>
+        <PackageReference Include="Common.Logging" Version="3.4.1"/>
     </ItemGroup>
 
     <PropertyGroup>

--- a/Difi.Oppslagstjeneste.Klient/OppslagstjenesteHelper.cs
+++ b/Difi.Oppslagstjeneste.Klient/OppslagstjenesteHelper.cs
@@ -6,13 +6,13 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
+using Common.Logging;
 using Difi.Oppslagstjeneste.Klient.Domene.Exceptions;
 using Difi.Oppslagstjeneste.Klient.Envelope;
 using Difi.Oppslagstjeneste.Klient.Handlers;
 using Difi.Oppslagstjeneste.Klient.Svar;
 using Difi.Oppslagstjeneste.Klient.Utilities;
 using Difi.Oppslagstjeneste.Klient.XmlValidation;
-using log4net;
 
 namespace Difi.Oppslagstjeneste.Klient
 {

--- a/Difi.Oppslagstjeneste.Klient/OppslagstjenesteKlient.cs
+++ b/Difi.Oppslagstjeneste.Klient/OppslagstjenesteKlient.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Common.Logging;
 using Difi.Oppslagstjeneste.Klient.Domene.Entiteter.Enums;
 using Difi.Oppslagstjeneste.Klient.Domene.Entiteter.Svar;
 using Difi.Oppslagstjeneste.Klient.Envelope;
 using Difi.Oppslagstjeneste.Klient.Scripts.XsdToCode.Code;
 using Difi.Oppslagstjeneste.Klient.Security;
 using Difi.Oppslagstjeneste.Klient.Svar;
-using log4net;
 using Person = Difi.Oppslagstjeneste.Klient.Domene.Entiteter.Person;
 
 namespace Difi.Oppslagstjeneste.Klient


### PR DESCRIPTION
Common.logging is used in earlier versions of this project and there is no good reason to replace it.
Bump common.logging to newest version.